### PR TITLE
fix/broken-detection

### DIFF
--- a/internal/semver/gitbranch.go
+++ b/internal/semver/gitbranch.go
@@ -29,8 +29,8 @@ func (mode GitBranchMode) Increment(targetVersion string) (nextVersion string, e
 	var branchName string
 	var matchedMode Mode
 
-	if branchName, err = mode.Commander.Output("git", "name-rev", "--name-only", "--refs='refs/heads/*'",
-		"--refs='refs/remotes/*'", "HEAD^2"); err != nil {
+	if branchName, err = mode.Commander.Output("git", "name-rev", "--name-only", "--refs=refs/heads/*",
+		"--refs=refs/remotes/*", "HEAD^2"); err != nil {
 		return
 	}
 

--- a/pkg/commands/predict-version.go
+++ b/pkg/commands/predict-version.go
@@ -32,7 +32,7 @@ func PredictVersionCommandRunE(cmd *cobra.Command, args []string) (err error) {
 	var version = versionAPI.GetVersionOrDefault(cli.DefaultVersion)
 
 	var mode = viper.GetString("semver.mode")
-	var modeDetectionMap = viper.GetStringMapStringSlice("semver.modes.detection")
+	var modeDetectionMap = viper.GetStringMapStringSlice("semver.detection")
 	var modeDetector = semver.NewModeDetector(modeDetectionMap)
 
 	var semverModeAPI = api.NewSemverModeAPI(modeDetector)


### PR DESCRIPTION
- fixed git branch mode by removing quotes from git refs in exec.Command inputs
- fixed detection map config path