### PR TITLE
[fix] - Use revparse to get source branch name

### DIFF
--- a/pkg/git/cli.go
+++ b/pkg/git/cli.go
@@ -54,11 +54,8 @@ func (api CLI) GetLatestCommitMessage() (message string, err error) {
 func (api CLI) GetMergedBranchName() (name string, err error) {
 	return api.Commander.Output(
 		"git",
-		"name-rev",
-		"--name-only",
-		"--refs=refs/heads/*",
-		"--refs=refs/remotes/*",
-		"HEAD^2",
+		"rev-parse",
+		"--abbrev-ref HEAD",
 	)
 }
 


### PR DESCRIPTION
## Description

I've set up sbot to use `mode = 'git-branch'`, however, I keep running up against this error:

```
Error: failed to detect mode from git branch name "Could not get sha1 for HEAD^2. Skipping.
" with delimiters "/"
```

I thought it may have been an issue with shell, so I had tried the actual command locally:

```shell
bash -c 'git name-rev --name-only --refs=refs/head/* --refs=refs/remotes/* HEAD^2'
```
That returns the same error, switching the command to:
```
bash -c 'git name-rev --name-only --refs=refs/head/* --refs=refs/remotes/* HEAD~2'
```
returns a branch name :success:
