### PR TITLE
fix/tag-order-with-multiple-prefixes

### DIFF
--- a/pkg/semver/find.go
+++ b/pkg/semver/find.go
@@ -1,15 +1,41 @@
 package semver
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
 
-// Find finds a valid semver version in a slice of strings.
-// Returns a version when found, otherwise an error stating no valid semver version has been found.
+	blangsemver "github.com/blang/semver/v4"
+)
+
+// Find finds the biggest valid semver version in a slice of strings.
+// The initial order of the versions does not matter.
+// Returns the biggest valid semver version if found, otherwise an error stating no valid semver version has been found.
 func Find(versions []string) (found string, err error) {
+	var parsedVersions blangsemver.Versions
+	var parsedVersion blangsemver.Version
+
 	for _, version := range versions {
-		if _, err = Parse(version); err == nil {
-			return version, err
+		if parsedVersion, err = Parse(version); err != nil {
+			continue
+		}
+
+		parsedVersions = append(parsedVersions, parsedVersion)
+	}
+
+	if len(parsedVersions) == 0 {
+		return found, fmt.Errorf("could not find a valid semver version")
+	}
+
+	blangsemver.Sort(parsedVersions)
+
+	var targetVersion = parsedVersions[len(parsedVersions)-1]
+
+	// necessary because blangsemver's Version.String() strips any prefix
+	for _, version := range versions {
+		if strings.Contains(version, targetVersion.String()) {
+			return version, nil
 		}
 	}
 
-	return found, fmt.Errorf("could not find a valid semver version")
+	return found, nil
 }

--- a/pkg/semver/find.go
+++ b/pkg/semver/find.go
@@ -33,7 +33,8 @@ func Find(versions []string) (found string, err error) {
 	// necessary because blangsemver's Version.String() strips any prefix
 	for _, version := range versions {
 		if strings.Contains(version, targetVersion.String()) {
-			return version, nil
+			found = version
+			break
 		}
 	}
 

--- a/pkg/semver/find_test.go
+++ b/pkg/semver/find_test.go
@@ -16,7 +16,7 @@ func TestFind(t *testing.T) {
 	var tests = []Test{
 		{Name: "FindVersionIfValid", Versions: []string{"v1.0.1", "v0.1.1", "v0.1.0"}, WantIndex: 0},
 		{Name: "SkipVersionIfInvalid", Versions: []string{"invalid1", "invalid2", "v0.1.0"}, WantIndex: 2},
-		{Name: "FindBiggestVersionWhenDifferentOrder", Versions: []string{"v1.3.1", "v0.2.0", "v2.3.0"}, WantIndex: 2},
+		{Name: "FindVersionWhenDifferentOrder", Versions: []string{"v1.3.1", "v0.2.0", "v2.3.0"}, WantIndex: 2},
 		{Name: "FindVersionWhenMultiplePrefixes", Versions: []string{"v1.3.1", "v0.2.0", "2.3.0"}, WantIndex: 2},
 	}
 

--- a/pkg/semver/find_test.go
+++ b/pkg/semver/find_test.go
@@ -14,9 +14,10 @@ func TestFind(t *testing.T) {
 	}
 
 	var tests = []Test{
-		{Name: "GetFirstVersionIfValid", Versions: []string{"v1.0.1", "v0.1.1", "v0.1.0"}, WantIndex: 0},
+		{Name: "FindVersionIfValid", Versions: []string{"v1.0.1", "v0.1.1", "v0.1.0"}, WantIndex: 0},
 		{Name: "SkipVersionIfInvalid", Versions: []string{"invalid1", "invalid2", "v0.1.0"}, WantIndex: 2},
-		{Name: "MaintainTagOrderWhenMultiplePrefixes", Versions: []string{"v1.3.1", "v0.2.0", "2.3.0"}, WantIndex: 2},
+		{Name: "FindBiggestVersionWhenDifferentOrder", Versions: []string{"v1.3.1", "v0.2.0", "v2.3.0"}, WantIndex: 2},
+		{Name: "FindVersionWhenMultiplePrefixes", Versions: []string{"v1.3.1", "v0.2.0", "2.3.0"}, WantIndex: 2},
 	}
 
 	for _, test := range tests {

--- a/pkg/semver/find_test.go
+++ b/pkg/semver/find_test.go
@@ -16,6 +16,7 @@ func TestFind(t *testing.T) {
 	var tests = []Test{
 		{Name: "GetFirstVersionIfValid", Versions: []string{"v1.0.1", "v0.1.1", "v0.1.0"}, WantIndex: 0},
 		{Name: "SkipVersionIfInvalid", Versions: []string{"invalid1", "invalid2", "v0.1.0"}, WantIndex: 2},
+		{Name: "MaintainTagOrderWhenMultiplePrefixes", Versions: []string{"v1.3.1", "v0.2.0", "2.3.0"}, WantIndex: 2},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Updated semver.Find to be able to work with an unordered slice of version and fix the issue mentioned in https://github.com/restechnica/semverbot/issues/49