### PR TITLE
Update support for tag prefixes

### DIFF
--- a/internal/mocks/mode.go
+++ b/internal/mocks/mode.go
@@ -15,7 +15,7 @@ func NewMockMode() *MockMode {
 
 // Increment mock increments a version.
 // Returns an incremented mock version.
-func (mock *MockMode) Increment(targetVersion string) (nextVersion string, err error) {
+func (mock *MockMode) Increment(_ string, targetVersion string) (nextVersion string, err error) {
 	args := mock.Called(targetVersion)
 	return args.String(0), args.Error(1)
 }

--- a/pkg/cli/commands/v1/get-version.go
+++ b/pkg/cli/commands/v1/get-version.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"fmt"
+	"github.com/spf13/viper"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -25,7 +26,9 @@ func NewGetVersionCommand() *cobra.Command {
 func GetVersionCommandRun(cmd *cobra.Command, args []string) {
 	log.Debug().Str("command", "v1.get-version").Msg("starting run...")
 
-	var options = &core.GetVersionOptions{DefaultVersion: cli.DefaultVersion}
+	var options = &core.GetVersionOptions{
+		GitTagPrefix:   viper.GetString(cli.GitTagsPrefixConfigKey),
+		DefaultVersion: cli.DefaultVersion}
 	log.Debug().Str("default", options.DefaultVersion).Msg("options")
 
 	var version = core.GetVersion(options)

--- a/pkg/cli/commands/v1/predict-version.go
+++ b/pkg/cli/commands/v1/predict-version.go
@@ -40,6 +40,7 @@ func PredictVersionCommandRunE(cmd *cobra.Command, args []string) (err error) {
 		DefaultVersion:      cli.DefaultVersion,
 		GitBranchDelimiters: viper.GetString(cli.ModesGitBranchDelimitersConfigKey),
 		GitCommitDelimiters: viper.GetString(cli.ModesGitCommitDelimitersConfigKey),
+		GitTagPrefix:        viper.GetString(cli.GitTagsPrefixConfigKey),
 		Mode:                viper.GetString(cli.ModeConfigKey),
 		SemverMap:           viper.GetStringMapStringSlice(cli.SemverMapConfigKey),
 	}

--- a/pkg/cli/commands/v1/release-version.go
+++ b/pkg/cli/commands/v1/release-version.go
@@ -34,25 +34,19 @@ func ReleaseVersionCommandPreRunE(cmd *cobra.Command, args []string) (err error)
 func ReleaseVersionCommandRunE(cmd *cobra.Command, args []string) (err error) {
 	log.Debug().Str("command", "v1.release-version").Msg("starting run...")
 
-	var predictOptions = &core.PredictVersionOptions{
-		DefaultVersion:      cli.DefaultVersion,
-		GitBranchDelimiters: viper.GetString(cli.ModesGitBranchDelimitersConfigKey),
-		GitCommitDelimiters: viper.GetString(cli.ModesGitCommitDelimitersConfigKey),
-		Mode:                viper.GetString(cli.ModeConfigKey),
-		SemverMap:           viper.GetStringMapStringSlice(cli.SemverMapConfigKey),
-	}
-
 	var releaseOptions = &core.ReleaseVersionOptions{
-		GitTagsPrefix: viper.GetString(cli.GitTagsPrefixConfigKey),
+		DefaultVersion: cli.DefaultVersion,
+		Mode:           viper.GetString(cli.ModeConfigKey),
+		GitTagsPrefix:  viper.GetString(cli.GitTagsPrefixConfigKey),
 	}
 
 	log.Debug().
-		Str("default", predictOptions.DefaultVersion).
-		Str("mode", predictOptions.Mode).
+		Str("default", releaseOptions.DefaultVersion).
+		Str("mode", releaseOptions.Mode).
 		Str("prefix", releaseOptions.GitTagsPrefix).
 		Msg("options")
 
-	if err = core.ReleaseVersion(predictOptions, releaseOptions); err != nil {
+	if err = core.ReleaseVersion(releaseOptions); err != nil {
 		err = cli.NewCommandError(err)
 	}
 

--- a/pkg/cli/commands/v1/update-version.go
+++ b/pkg/cli/commands/v1/update-version.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/restechnica/semverbot/pkg/cli"
 	"github.com/restechnica/semverbot/pkg/core"
@@ -24,7 +25,11 @@ func NewUpdateVersionCommand() *cobra.Command {
 func UpdateVersionCommandRunE(cmd *cobra.Command, args []string) (err error) {
 	log.Debug().Str("command", "v1.update-version").Msg("starting run...")
 
-	if err = core.UpdateVersion(); err != nil {
+	var updateOptions = &core.UpdateVersionOptions{
+		GitTagsPrefix: viper.GetString(cli.GitTagsPrefixConfigKey),
+	}
+
+	if err = core.UpdateVersion(updateOptions); err != nil {
 		err = cli.NewCommandError(err)
 	}
 

--- a/pkg/core/get.go
+++ b/pkg/core/get.go
@@ -5,12 +5,13 @@ import (
 )
 
 type GetVersionOptions struct {
+	GitTagPrefix   string
 	DefaultVersion string
 }
 
 // GetVersion gets the current version.
 // Returns the current version.
 func GetVersion(options *GetVersionOptions) string {
-	var versionAPI = versions.NewAPI()
+	var versionAPI = versions.NewAPI(options.GitTagPrefix)
 	return versionAPI.GetVersionOrDefault(options.DefaultVersion)
 }

--- a/pkg/core/predict.go
+++ b/pkg/core/predict.go
@@ -10,6 +10,7 @@ type PredictVersionOptions struct {
 	DefaultVersion      string
 	GitBranchDelimiters string
 	GitCommitDelimiters string
+	GitTagPrefix        string
 	Mode                string
 	SemverMap           semver.Map
 }
@@ -21,7 +22,7 @@ func PredictVersion(options *PredictVersionOptions) (prediction string, err erro
 	var gitBranchMode = modes.NewGitBranchMode(options.GitBranchDelimiters, options.SemverMap)
 	var gitCommitMode = modes.NewGitCommitMode(options.GitCommitDelimiters, options.SemverMap)
 
-	var versionAPI = versions.NewAPI()
+	var versionAPI = versions.NewAPI(options.GitTagPrefix)
 	var version = versionAPI.GetVersionOrDefault(options.DefaultVersion)
 
 	var modeAPI = modes.NewAPI(gitBranchMode, gitCommitMode)

--- a/pkg/core/push.go
+++ b/pkg/core/push.go
@@ -10,7 +10,7 @@ type PushVersionOptions struct {
 // PushVersion pushes the current version.
 // Returns an error if the push went wrong.
 func PushVersion(options *PushVersionOptions) (err error) {
-	var versionAPI = versions.NewAPI()
+	var versionAPI = versions.NewAPI(options.GitTagsPrefix)
 	var version = versionAPI.GetVersionOrDefault(options.DefaultVersion)
-	return versionAPI.PushVersion(version, options.GitTagsPrefix)
+	return versionAPI.PushVersion(version)
 }

--- a/pkg/core/release.go
+++ b/pkg/core/release.go
@@ -16,13 +16,22 @@ type ReleaseVersionOptions struct {
 
 // ReleaseVersion releases a new version.
 // Returns an error if anything went wrong with the prediction or releasing.
-func ReleaseVersion(predictOptions *PredictVersionOptions, releaseOptions *ReleaseVersionOptions) error {
-	var versionAPI = versions.NewAPI()
-	var predictedVersion, err = PredictVersion(predictOptions)
+func ReleaseVersion(releaseOptions *ReleaseVersionOptions) error {
+	predictOptions := PredictVersionOptions{
+		DefaultVersion:      releaseOptions.DefaultVersion,
+		GitBranchDelimiters: releaseOptions.GitBranchDelimiters,
+		GitCommitDelimiters: releaseOptions.GitCommitDelimiters,
+		GitTagPrefix:        releaseOptions.GitTagsPrefix,
+		Mode:                releaseOptions.Mode,
+		SemverMap:           releaseOptions.SemverMap,
+	}
+
+	var versionAPI = versions.NewAPI(predictOptions.GitTagPrefix)
+	var predictedVersion, err = PredictVersion(&predictOptions)
 
 	if err != nil {
 		return err
 	}
 
-	return versionAPI.ReleaseVersion(predictedVersion, releaseOptions.GitTagsPrefix)
+	return versionAPI.ReleaseVersion(predictedVersion)
 }

--- a/pkg/core/update.go
+++ b/pkg/core/update.go
@@ -4,9 +4,13 @@ import (
 	"github.com/restechnica/semverbot/pkg/versions"
 )
 
+type UpdateVersionOptions struct {
+	GitTagsPrefix string
+}
+
 // UpdateVersion updates to the latest version.
 // Returns an error if updating the version went wrong.
-func UpdateVersion() error {
-	var versionAPI = versions.NewAPI()
+func UpdateVersion(updateOptions *UpdateVersionOptions) error {
+	var versionAPI = versions.NewAPI(updateOptions.GitTagsPrefix)
 	return versionAPI.UpdateVersion()
 }

--- a/pkg/modes/auto.go
+++ b/pkg/modes/auto.go
@@ -21,9 +21,9 @@ func NewAutoMode(modes []Mode) AutoMode {
 // Increment increments a given version using AutoMode.
 // It will attempt to increment the target version with its internal modes and defaults to PatchMode as a last resort.
 // Returns the incremented version or an error if anything went wrong.
-func (autoMode AutoMode) Increment(targetVersion string) (nextVersion string, err error) {
+func (autoMode AutoMode) Increment(prefix string, targetVersion string) (nextVersion string, err error) {
 	for _, mode := range autoMode.Modes {
-		if nextVersion, err = mode.Increment(targetVersion); err == nil {
+		if nextVersion, err = mode.Increment(prefix, targetVersion); err == nil {
 			return nextVersion, err
 		}
 
@@ -32,7 +32,7 @@ func (autoMode AutoMode) Increment(targetVersion string) (nextVersion string, er
 
 	log.Warn().Msg("falling back to patch mode")
 
-	return PatchMode{}.Increment(targetVersion)
+	return PatchMode{}.Increment(prefix, targetVersion)
 }
 
 // String returns a string representation of an instance.

--- a/pkg/modes/auto_test.go
+++ b/pkg/modes/auto_test.go
@@ -23,24 +23,25 @@ func TestAutoMode_Increment(t *testing.T) {
 	type Test struct {
 		Modes   []Mode
 		Name    string
+		Prefix  string
 		Version string
 		Want    string
 	}
 
 	var mockMode = mocks.NewMockMode()
-	mockMode.On("Increment", mock.Anything).Return("", fmt.Errorf("some-error"))
+	mockMode.On("Increment", mock.Anything, mock.Anything).Return("", fmt.Errorf("some-error"))
 
 	var tests = []Test{
-		{Name: "IncrementMajor", Modes: []Mode{NewMajorMode()}, Version: "0.0.0", Want: "1.0.0"},
-		{Name: "IncrementMinor", Modes: []Mode{NewMinorMode()}, Version: "0.0.0", Want: "0.1.0"},
-		{Name: "IncrementPatch", Modes: []Mode{NewPatchMode()}, Version: "0.0.0", Want: "0.0.1"},
-		{Name: "DefaultToPatchIfModeSliceEmpty", Modes: []Mode{}, Version: "0.0.0", Want: "0.0.1"},
-		{Name: "IncrementWithSecondModeAfterFirstFailed", Modes: []Mode{mockMode, NewMinorMode()}, Version: "0.0.0", Want: "0.1.0"},
+		{Name: "IncrementMajor", Prefix: "v", Modes: []Mode{NewMajorMode()}, Version: "0.0.0", Want: "1.0.0"},
+		{Name: "IncrementMinor", Prefix: "v", Modes: []Mode{NewMinorMode()}, Version: "0.0.0", Want: "0.1.0"},
+		{Name: "IncrementPatch", Prefix: "v", Modes: []Mode{NewPatchMode()}, Version: "0.0.0", Want: "0.0.1"},
+		{Name: "DefaultToPatchIfModeSliceEmpty", Prefix: "v", Modes: []Mode{}, Version: "0.0.0", Want: "0.0.1"},
+		{Name: "IncrementWithSecondModeAfterFirstFailed", Prefix: "v", Modes: []Mode{mockMode, NewMinorMode()}, Version: "0.0.0", Want: "0.1.0"},
 	}
 
 	for _, test := range tests {
 		var mode = NewAutoMode(test.Modes)
-		var got, err = mode.Increment(test.Version)
+		var got, err = mode.Increment(test.Prefix, test.Version)
 
 		assert.NoError(t, err)
 		assert.IsType(t, test.Want, got, `want: "%s, got: "%s"`, test.Want, got)

--- a/pkg/modes/gitbranch.go
+++ b/pkg/modes/gitbranch.go
@@ -28,7 +28,7 @@ func NewGitBranchMode(delimiters string, semverMap semver.Map) GitBranchMode {
 // Increment increments the semver level based on the naming of the source branch of a git merge.
 // Returns the incremented version or an error if the last git commit is not a merge or if no mode was detected
 // based on the branch name.
-func (mode GitBranchMode) Increment(targetVersion string) (nextVersion string, err error) {
+func (mode GitBranchMode) Increment(prefix string, targetVersion string) (nextVersion string, err error) {
 	var branchName string
 	var matchedMode Mode
 
@@ -46,7 +46,7 @@ func (mode GitBranchMode) Increment(targetVersion string) (nextVersion string, e
 		return nextVersion, err
 	}
 
-	return matchedMode.Increment(targetVersion)
+	return matchedMode.Increment(prefix, targetVersion)
 }
 
 // DetectMode detects the mode (patch, minor, major) based on a git branch name.

--- a/pkg/modes/gitbranch_test.go
+++ b/pkg/modes/gitbranch_test.go
@@ -113,15 +113,16 @@ func TestGitBranchMode_Increment(t *testing.T) {
 		BranchName string
 		Delimiters string
 		Name       string
+		Prefix     string
 		SemverMap  semver.Map
 		Version    string
 		Want       string
 	}
 
 	var tests = []Test{
-		{Name: "IncrementPatch", BranchName: "fix/some-bug", Delimiters: "/", SemverMap: semverMap, Version: "0.0.0", Want: "0.0.1"},
-		{Name: "IncrementMinor", BranchName: "feature/some-bug", Delimiters: "/", SemverMap: semverMap, Version: "0.0.1", Want: "0.1.0"},
-		{Name: "IncrementMajor", BranchName: "release/some-bug", Delimiters: "/", SemverMap: semverMap, Version: "0.1.0", Want: "1.0.0"},
+		{Name: "IncrementPatch", BranchName: "fix/some-bug", Delimiters: "/", Prefix: "v", SemverMap: semverMap, Version: "0.0.0", Want: "0.0.1"},
+		{Name: "IncrementMinor", BranchName: "feature/some-bug", Delimiters: "/", Prefix: "v", SemverMap: semverMap, Version: "0.0.1", Want: "0.1.0"},
+		{Name: "IncrementMajor", BranchName: "release/some-bug", Delimiters: "/", Prefix: "v", SemverMap: semverMap, Version: "0.1.0", Want: "1.0.0"},
 	}
 
 	for _, test := range tests {
@@ -132,7 +133,7 @@ func TestGitBranchMode_Increment(t *testing.T) {
 			var mode = NewGitBranchMode(test.Delimiters, test.SemverMap)
 			mode.GitAPI = gitAPI
 
-			var got, err = mode.Increment(test.Version)
+			var got, err = mode.Increment(test.Prefix, test.Version)
 
 			assert.NoError(t, err)
 			assert.IsType(t, test.Want, got, `want: '%s, got: '%s'`, test.Want, got)
@@ -148,7 +149,7 @@ func TestGitBranchMode_Increment(t *testing.T) {
 		var mode = NewGitBranchMode("/", semverMap)
 		mode.GitAPI = gitAPI
 
-		var _, got = mode.Increment("0.0.0")
+		var _, got = mode.Increment("v", "0.0.0")
 
 		assert.Error(t, got)
 		assert.Equal(t, want, got, `want: '%s, got: '%s'`, want, got)
@@ -163,7 +164,7 @@ func TestGitBranchMode_Increment(t *testing.T) {
 		var mode = NewGitBranchMode("/", semverMap)
 		mode.GitAPI = gitAPI
 
-		var _, got = mode.Increment("0.0.0")
+		var _, got = mode.Increment("v", "0.0.0")
 
 		assert.Error(t, got)
 		assert.Equal(t, want, got, `want: '%s, got: '%s'`, want, got)
@@ -176,7 +177,7 @@ func TestGitBranchMode_Increment(t *testing.T) {
 		var mode = NewGitBranchMode("/", semverMap)
 		mode.GitAPI = gitAPI
 
-		var _, got = mode.Increment("0.0.0")
+		var _, got = mode.Increment("v", "0.0.0")
 
 		assert.Error(t, got)
 	})
@@ -188,7 +189,7 @@ func TestGitBranchMode_Increment(t *testing.T) {
 		var mode = NewGitBranchMode("/", semverMap)
 		mode.GitAPI = gitAPI
 
-		var _, got = mode.Increment("invalid")
+		var _, got = mode.Increment("v", "invalid")
 
 		assert.Error(t, got)
 	})

--- a/pkg/modes/gitcommit.go
+++ b/pkg/modes/gitcommit.go
@@ -27,7 +27,7 @@ func NewGitCommitMode(delimiters string, semverMap semver.Map) GitCommitMode {
 
 // Increment increments a given version based on the latest git commit message.
 // Returns the incremented version or an error if it failed to detect the mode based on the git commit.
-func (mode GitCommitMode) Increment(targetVersion string) (nextVersion string, err error) {
+func (mode GitCommitMode) Increment(prefix string, targetVersion string) (nextVersion string, err error) {
 	var message string
 	var detectedMode Mode
 
@@ -39,7 +39,7 @@ func (mode GitCommitMode) Increment(targetVersion string) (nextVersion string, e
 		return
 	}
 
-	return detectedMode.Increment(targetVersion)
+	return detectedMode.Increment(prefix, targetVersion)
 }
 
 // DetectMode detects the mode (patch, minor, major) based on a git commit message.

--- a/pkg/modes/gitcommit_test.go
+++ b/pkg/modes/gitcommit_test.go
@@ -116,16 +116,17 @@ func TestGitCommitMode_Increment(t *testing.T) {
 		CommitMessage string
 		Delimiters    string
 		Name          string
+		Prefix        string
 		SemverMap     semver.Map
 		Version       string
 		Want          string
 	}
 
 	var tests = []Test{
-		{Name: "IncrementPatch", CommitMessage: "fix] some-bug", Delimiters: "[]", SemverMap: semverMap, Version: "0.0.0", Want: "0.0.1"},
-		{Name: "IncrementPatch", CommitMessage: "[fi] some/bug", Delimiters: "/", SemverMap: semverMap, Version: "0.0.0", Want: "0.0.1"},
-		{Name: "IncrementMinor", CommitMessage: "[feature] some-feat", Delimiters: "[]", SemverMap: semverMap, Version: "0.0.1", Want: "0.1.0"},
-		{Name: "IncrementMajor", CommitMessage: "[release] some-release", Delimiters: "[]", SemverMap: semverMap, Version: "0.1.0", Want: "1.0.0"},
+		{Name: "IncrementPatch", CommitMessage: "fix] some-bug", Delimiters: "[]", Prefix: "v", SemverMap: semverMap, Version: "0.0.0", Want: "0.0.1"},
+		{Name: "IncrementPatch", CommitMessage: "[fi] some/bug", Delimiters: "/", Prefix: "v", SemverMap: semverMap, Version: "0.0.0", Want: "0.0.1"},
+		{Name: "IncrementMinor", CommitMessage: "[feature] some-feat", Delimiters: "[]", Prefix: "v", SemverMap: semverMap, Version: "0.0.1", Want: "0.1.0"},
+		{Name: "IncrementMajor", CommitMessage: "[release] some-release", Delimiters: "[]", Prefix: "v", SemverMap: semverMap, Version: "0.1.0", Want: "1.0.0"},
 	}
 
 	for _, test := range tests {
@@ -136,7 +137,7 @@ func TestGitCommitMode_Increment(t *testing.T) {
 			var mode = NewGitCommitMode(test.Delimiters, test.SemverMap)
 			mode.GitAPI = gitAPI
 
-			var got, err = mode.Increment(test.Version)
+			var got, err = mode.Increment(test.Prefix, test.Version)
 
 			assert.NoError(t, err)
 			assert.IsType(t, test.Want, got, `want: '%s, got: '%s'`, test.Want, got)
@@ -152,7 +153,7 @@ func TestGitCommitMode_Increment(t *testing.T) {
 		var mode = NewGitCommitMode("[]", semverMap)
 		mode.GitAPI = gitAPI
 
-		var _, got = mode.Increment("0.0.0")
+		var _, got = mode.Increment("v", "0.0.0")
 
 		assert.Error(t, got)
 		assert.Equal(t, want, got, `want: '%s, got: '%s'`, want, got)
@@ -165,7 +166,7 @@ func TestGitCommitMode_Increment(t *testing.T) {
 		var mode = NewGitCommitMode("/", semverMap)
 		mode.GitAPI = gitAPI
 
-		var _, got = mode.Increment("0.0.0")
+		var _, got = mode.Increment("v", "0.0.0")
 
 		assert.Error(t, got)
 	})
@@ -177,7 +178,7 @@ func TestGitCommitMode_Increment(t *testing.T) {
 		var mode = NewGitCommitMode("[]", semverMap)
 		mode.GitAPI = gitAPI
 
-		var _, got = mode.Increment("invalid")
+		var _, got = mode.Increment("v", "invalid")
 
 		assert.Error(t, got)
 	})

--- a/pkg/modes/major.go
+++ b/pkg/modes/major.go
@@ -2,7 +2,6 @@ package modes
 
 import (
 	blangsemver "github.com/blang/semver/v4"
-
 	"github.com/restechnica/semverbot/pkg/semver"
 )
 
@@ -21,10 +20,10 @@ func NewMajorMode() MajorMode {
 
 // Increment increments a given version using the MajorMode.
 // Returns the incremented version.
-func (mode MajorMode) Increment(targetVersion string) (nextVersion string, err error) {
+func (mode MajorMode) Increment(prefix string, targetVersion string) (nextVersion string, err error) {
 	var version blangsemver.Version
 
-	if version, err = semver.Parse(targetVersion); err != nil {
+	if version, err = semver.Parse(prefix, targetVersion); err != nil {
 		return
 	}
 

--- a/pkg/modes/major_test.go
+++ b/pkg/modes/major_test.go
@@ -24,7 +24,7 @@ func TestMajorMode_Increment(t *testing.T) {
 
 	for _, test := range tests {
 		var mode = NewMajorMode()
-		var got, err = mode.Increment(test.Version)
+		var got, err = mode.Increment("v", test.Version)
 
 		assert.NoError(t, err)
 		assert.IsType(t, test.Want, got, `want: "%s, got: "%s"`, test.Want, got)
@@ -32,7 +32,7 @@ func TestMajorMode_Increment(t *testing.T) {
 
 	t.Run("ReturnErrorOnInvalidVersion", func(t *testing.T) {
 		var mode = NewMajorMode()
-		var _, got = mode.Increment("invalid")
+		var _, got = mode.Increment("v", "invalid")
 		assert.Error(t, got)
 	})
 }

--- a/pkg/modes/minor.go
+++ b/pkg/modes/minor.go
@@ -21,10 +21,10 @@ func NewMinorMode() MinorMode {
 
 // Increment increments a given version using the MinorMode.
 // Returns the incremented version.
-func (mode MinorMode) Increment(targetVersion string) (nextVersion string, err error) {
+func (mode MinorMode) Increment(prefix string, targetVersion string) (nextVersion string, err error) {
 	var version blangsemver.Version
 
-	if version, err = semver.Parse(targetVersion); err != nil {
+	if version, err = semver.Parse(prefix, targetVersion); err != nil {
 		return
 	}
 

--- a/pkg/modes/minor_test.go
+++ b/pkg/modes/minor_test.go
@@ -9,20 +9,21 @@ import (
 func TestMinorMode_Increment(t *testing.T) {
 	type Test struct {
 		Name    string
+		Prefix  string
 		Version string
 		Want    string
 	}
 
 	var tests = []Test{
-		{Name: "IncrementMinor", Version: "0.0.0", Want: "0.1.0"},
-		{Name: "DiscardPrefix", Version: "v0.1.0", Want: "0.2.0"},
-		{Name: "DiscardPrebuild", Version: "0.2.0-pre+001", Want: "0.3.0"},
-		{Name: "ResetPatch", Version: "3.0.4", Want: "3.1.0"},
+		{Name: "IncrementMinor", Prefix: "v", Version: "0.0.0", Want: "0.1.0"},
+		{Name: "DiscardPrefix", Prefix: "v", Version: "v0.1.0", Want: "0.2.0"},
+		{Name: "DiscardPrebuild", Prefix: "v", Version: "0.2.0-pre+001", Want: "0.3.0"},
+		{Name: "ResetPatch", Prefix: "v", Version: "3.0.4", Want: "3.1.0"},
 	}
 
 	for _, test := range tests {
 		var mode = NewMinorMode()
-		var got, err = mode.Increment(test.Version)
+		var got, err = mode.Increment(test.Prefix, test.Version)
 
 		assert.NoError(t, err)
 		assert.IsType(t, test.Want, got, `want: "%s, got: "%s"`, test.Want, got)
@@ -30,7 +31,7 @@ func TestMinorMode_Increment(t *testing.T) {
 
 	t.Run("ReturnErrorOnInvalidVersion", func(t *testing.T) {
 		var mode = NewMinorMode()
-		var _, got = mode.Increment("invalid")
+		var _, got = mode.Increment("v", "invalid")
 		assert.Error(t, got)
 	})
 }

--- a/pkg/modes/mode.go
+++ b/pkg/modes/mode.go
@@ -2,5 +2,5 @@ package modes
 
 // Mode interface which increments a specific semver level.
 type Mode interface {
-	Increment(targetVersion string) (nextVersion string, err error)
+	Increment(prefix string, targetVersion string) (nextVersion string, err error)
 }

--- a/pkg/modes/patch.go
+++ b/pkg/modes/patch.go
@@ -21,10 +21,10 @@ func NewPatchMode() PatchMode {
 
 // Increment increments a given version using the PatchMode.
 // Returns the incremented version.
-func (mode PatchMode) Increment(targetVersion string) (nextVersion string, err error) {
+func (mode PatchMode) Increment(prefix string, targetVersion string) (nextVersion string, err error) {
 	var version blangsemver.Version
 
-	if version, err = semver.Parse(targetVersion); err != nil {
+	if version, err = semver.Parse(prefix, targetVersion); err != nil {
 		return
 	}
 

--- a/pkg/modes/patch_test.go
+++ b/pkg/modes/patch_test.go
@@ -9,20 +9,21 @@ import (
 func TestPatchMode_Increment(t *testing.T) {
 	type Test struct {
 		Name    string
+		Prefix  string
 		Version string
 		Want    string
 	}
 
 	var tests = []Test{
-		{Name: "IncrementPatch", Version: "0.0.0", Want: "0.0.1"},
-		{Name: "DiscardPrefix", Version: "v0.0.1", Want: "0.0.2"},
-		{Name: "DiscardPrebuild", Version: "0.0.2-pre+001", Want: "0.0.3"},
-		{Name: "NoResets", Version: "3.2.0", Want: "3.2.1"},
+		{Name: "IncrementPatch", Prefix: "v", Version: "0.0.0", Want: "0.0.1"},
+		{Name: "DiscardPrefix", Prefix: "v", Version: "v0.0.1", Want: "0.0.2"},
+		{Name: "DiscardPrebuild", Prefix: "v", Version: "0.0.2-pre+001", Want: "0.0.3"},
+		{Name: "NoResets", Prefix: "v", Version: "3.2.0", Want: "3.2.1"},
 	}
 
 	for _, test := range tests {
 		var mode = NewPatchMode()
-		var got, err = mode.Increment(test.Version)
+		var got, err = mode.Increment(test.Prefix, test.Version)
 
 		assert.NoError(t, err)
 		assert.IsType(t, test.Want, got, `want: "%s, got: "%s"`, test.Want, got)
@@ -30,7 +31,7 @@ func TestPatchMode_Increment(t *testing.T) {
 
 	t.Run("ReturnErrorOnInvalidVersion", func(t *testing.T) {
 		var mode = NewPatchMode()
-		var _, got = mode.Increment("invalid")
+		var _, got = mode.Increment("v", "invalid")
 		assert.Error(t, got)
 	})
 }

--- a/pkg/semver/find.go
+++ b/pkg/semver/find.go
@@ -10,12 +10,12 @@ import (
 // Find finds the biggest valid semver version in a slice of strings.
 // The initial order of the versions does not matter.
 // Returns the biggest valid semver version if found, otherwise an error stating no valid semver version has been found.
-func Find(versions []string) (found string, err error) {
+func Find(prefix string, versions []string) (found string, err error) {
 	var parsedVersions blangsemver.Versions
 	var parsedVersion blangsemver.Version
 
 	for _, version := range versions {
-		if parsedVersion, err = Parse(version); err != nil {
+		if parsedVersion, err = Parse(prefix, version); err != nil {
 			continue
 		}
 

--- a/pkg/semver/find_test.go
+++ b/pkg/semver/find_test.go
@@ -9,23 +9,24 @@ import (
 func TestFind(t *testing.T) {
 	type Test struct {
 		Name      string
+		Prefix    string
 		Versions  []string
 		WantIndex int
 	}
 
 	var tests = []Test{
-		{Name: "FindVersionIfValid", Versions: []string{"v1.0.1", "v0.1.1", "v0.1.0"}, WantIndex: 0},
-		{Name: "SkipVersionIfInvalid", Versions: []string{"invalid1", "invalid2", "v0.1.0"}, WantIndex: 2},
-		{Name: "FindVersionWhenDifferentOrder", Versions: []string{"v1.3.1", "v0.2.0", "v2.3.0"}, WantIndex: 2},
-		{Name: "FindVersionWhenMultiplePrefixes", Versions: []string{"v1.3.1", "v0.2.0", "2.3.0"}, WantIndex: 2},
+		{Name: "FindVersionIfValid", Prefix: "v", Versions: []string{"v1.0.1", "v0.1.1", "v0.1.0"}, WantIndex: 0},
+		{Name: "FindVersionWithCustomPrefixIfValid", Prefix: "test-", Versions: []string{"test-1.0.1", "test-0.1.1", "test-0.1.0"}, WantIndex: 0},
+		{Name: "SkipVersionIfInvalid", Prefix: "v", Versions: []string{"invalid1", "invalid2", "v0.1.0"}, WantIndex: 2},
+		{Name: "FindVersionWhenDifferentOrder", Prefix: "v", Versions: []string{"v1.3.1", "v0.2.0", "v2.3.0"}, WantIndex: 2},
+		{Name: "FindVersionWhenMultiplePrefixes", Prefix: "v", Versions: []string{"v1.3.1", "v0.2.0", "2.3.0"}, WantIndex: 2},
 	}
 
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
 			var versions = test.Versions
-
 			var want = versions[test.WantIndex]
-			var got, err = Find(versions)
+			var got, err = Find(test.Prefix, versions)
 
 			assert.Equal(t, want, got, `want: "%s", got: "%s"`, want, got)
 			assert.NoError(t, err)
@@ -44,7 +45,7 @@ func TestFind(t *testing.T) {
 
 	for _, test := range errorTests {
 		t.Run(test.Name, func(t *testing.T) {
-			var _, got = Find(test.Versions)
+			var _, got = Find("v", test.Versions)
 			assert.Error(t, got)
 		})
 	}

--- a/pkg/semver/parse.go
+++ b/pkg/semver/parse.go
@@ -1,11 +1,15 @@
 package semver
 
-import blangsemver "github.com/blang/semver/v4"
+import (
+	blangsemver "github.com/blang/semver/v4"
+	"strings"
+)
 
 // Parse parses a version string into a semver version struct.
 // It tolerates certain version specifications that do not strictly adhere to semver specs.
 // See the library documentation for more information.
 // Returns the parsed blang/semver/v4 Version.
-func Parse(version string) (blangsemver.Version, error) {
-	return blangsemver.ParseTolerant(version)
+func Parse(prefix string, version string) (blangsemver.Version, error) {
+	var mappedVersion = strings.Replace(version, prefix, "v", 1)
+	return blangsemver.ParseTolerant(mappedVersion)
 }

--- a/pkg/semver/parse_test.go
+++ b/pkg/semver/parse_test.go
@@ -32,7 +32,7 @@ func TestParse(t *testing.T) {
 			var version = fmt.Sprintf(`%s%s.%s.%s%s`, test.Prefix, test.Major, test.Minor, test.Patch,
 				test.Prebuild)
 
-			var got, err = Parse(version)
+			var got, err = Parse(test.Prefix, version)
 
 			assert.Equal(t, test.Major, fmt.Sprint(got.Major), `want: "%s", got: "%d"`, test.Major, got.Major)
 			assert.Equal(t, test.Minor, fmt.Sprint(got.Minor), `want: "%s", got: "%s"`, test.Minor, got.Minor)

--- a/pkg/semver/trim.go
+++ b/pkg/semver/trim.go
@@ -1,14 +1,19 @@
 package semver
 
-import blangsemver "github.com/blang/semver/v4"
+import (
+	blangsemver "github.com/blang/semver/v4"
+	"strings"
+)
 
 // Trim trims a semver version string of anything but major.minor.patch information.
 // Returns the trimmed semver version.
-func Trim(version string) (string, error) {
+func Trim(prefix string, version string) (string, error) {
 	var semverVersion blangsemver.Version
 	var err error
 
-	if semverVersion, err = Parse(version); err != nil {
+	var mappedVersion = strings.Replace(version, prefix, prefix, 1)
+
+	if semverVersion, err = Parse(prefix, mappedVersion); err != nil {
 		return version, err
 	}
 

--- a/pkg/semver/trim_test.go
+++ b/pkg/semver/trim_test.go
@@ -35,7 +35,7 @@ func TestTrim(t *testing.T) {
 			var want = strings.ReplaceAll(version, test.Prefix, "")
 			want = strings.ReplaceAll(want, test.Prebuild, "")
 
-			var got, err = Trim(version)
+			var got, err = Trim(test.Prefix, version)
 
 			assert.Equal(t, want, got, `want: "%s", got: "%s"`, want, got)
 
@@ -62,7 +62,7 @@ func TestTrim(t *testing.T) {
 
 	for _, test := range errorTests {
 		t.Run(test.Name, func(t *testing.T) {
-			var _, got = Trim(test.Version)
+			var _, got = Trim("v", test.Version)
 			assert.Error(t, got)
 		})
 	}

--- a/pkg/versions/api.go
+++ b/pkg/versions/api.go
@@ -12,13 +12,14 @@ import (
 
 // API an API to work with versions.
 type API struct {
+	Prefix string
 	GitAPI git.API
 }
 
 // NewAPI creates a new version API.
 // Returns the new API.
-func NewAPI() API {
-	return API{GitAPI: git.NewCLI()}
+func NewAPI(prefix string) API {
+	return API{Prefix: prefix, GitAPI: git.NewCLI()}
 }
 
 // GetVersion gets the latest valid semver version from the git tags.
@@ -34,11 +35,11 @@ func (api API) GetVersion() (currentVersion string, err error) {
 	// strip all newlines
 	var versions = strings.Fields(tags)
 
-	if currentVersion, err = semver.Find(versions); err != nil {
+	if currentVersion, err = semver.Find(api.Prefix, versions); err != nil {
 		return currentVersion, err
 	}
 
-	return semver.Trim(currentVersion)
+	return semver.Trim(api.Prefix, currentVersion)
 }
 
 // GetVersionOrDefault gets the current version or a default version if it failed.
@@ -63,22 +64,22 @@ func (api API) GetVersionOrDefault(defaultVersion string) (version string) {
 // Returns the next version or an error if the increment failed.
 func (api API) PredictVersion(version string, mode modes.Mode) (string, error) {
 	log.Info().Msg("predicting version...")
-	return mode.Increment(version)
+	return mode.Increment(api.Prefix, version)
 }
 
 // ReleaseVersion releases a version by creating an annotated git tag with a prefix.
 // Returns an error if the tag creation failed.
-func (api API) ReleaseVersion(version string, prefix string) (err error) {
+func (api API) ReleaseVersion(version string) (err error) {
 	log.Info().Msg("releasing version...")
-	var prefixedVersion = AddPrefix(version, prefix)
+	var prefixedVersion = AddPrefix(version, api.Prefix)
 	return api.GitAPI.CreateAnnotatedTag(prefixedVersion)
 }
 
 // PushVersion pushes a version by pushing a git tag with a prefix.
 // Returns an error if pushing the tag failed.
-func (api API) PushVersion(version string, prefix string) (err error) {
+func (api API) PushVersion(version string) (err error) {
 	log.Info().Msg("pushing version...")
-	var prefixedVersion = AddPrefix(version, prefix)
+	var prefixedVersion = AddPrefix(version, api.Prefix)
 	return api.GitAPI.PushTag(prefixedVersion)
 }
 

--- a/pkg/versions/api_test.go
+++ b/pkg/versions/api_test.go
@@ -22,11 +22,12 @@ func init() {
 func TestAPI_GetVersion(t *testing.T) {
 	type Test struct {
 		Name    string
+		Prefix  string
 		Version string
 	}
 
 	var tests = []Test{
-		{Name: "ReturnVersion", Version: "0.0.0"},
+		{Name: "ReturnVersion", Prefix: "v", Version: "0.0.0"},
 	}
 
 	for _, test := range tests {
@@ -35,7 +36,7 @@ func TestAPI_GetVersion(t *testing.T) {
 			cmder.On("Output", mock.Anything, mock.Anything).Return(test.Version, nil)
 
 			var gitAPI = git.CLI{Commander: cmder}
-			var versionAPI = API{GitAPI: gitAPI}
+			var versionAPI = API{Prefix: test.Prefix, GitAPI: gitAPI}
 
 			var got, err = versionAPI.GetVersion()
 
@@ -45,12 +46,13 @@ func TestAPI_GetVersion(t *testing.T) {
 	}
 
 	type GitErrorTest struct {
-		Error error
-		Name  string
+		Error  error
+		Name   string
+		Prefix string
 	}
 
 	var gitErrorTests = []GitErrorTest{
-		{Name: "ReturnErrorOnGitError", Error: fmt.Errorf("some-error")},
+		{Name: "ReturnErrorOnGitError", Prefix: "v", Error: fmt.Errorf("some-error")},
 	}
 
 	for _, test := range gitErrorTests {
@@ -59,7 +61,7 @@ func TestAPI_GetVersion(t *testing.T) {
 			cmder.On("Output", mock.Anything, mock.Anything).Return("", test.Error)
 
 			var gitAPI = git.CLI{Commander: cmder}
-			var versionAPI = API{GitAPI: gitAPI}
+			var versionAPI = API{Prefix: test.Prefix, GitAPI: gitAPI}
 
 			var _, got = versionAPI.GetVersion()
 
@@ -71,6 +73,7 @@ func TestAPI_GetVersion(t *testing.T) {
 	type SemverErrorTest struct {
 		Error    error
 		Name     string
+		Prefix   string
 		Versions string
 	}
 
@@ -85,7 +88,7 @@ func TestAPI_GetVersion(t *testing.T) {
 			cmder.On("Output", mock.Anything, mock.Anything).Return(test.Versions, nil)
 
 			var gitAPI = git.CLI{Commander: cmder}
-			var versionAPI = API{GitAPI: gitAPI}
+			var versionAPI = API{Prefix: test.Prefix, GitAPI: gitAPI}
 
 			var _, got = versionAPI.GetVersion()
 
@@ -98,11 +101,12 @@ func TestAPI_GetVersion(t *testing.T) {
 func TestAPI_GetVersionOrDefault(t *testing.T) {
 	type Test struct {
 		Name    string
+		Prefix  string
 		Version string
 	}
 
 	var tests = []Test{
-		{Name: "ReturnVersionWithoutError", Version: "0.0.0"},
+		{Name: "ReturnVersionWithoutError", Prefix: "v", Version: "0.0.0"},
 	}
 
 	for _, test := range tests {
@@ -111,7 +115,7 @@ func TestAPI_GetVersionOrDefault(t *testing.T) {
 			cmder.On("Output", mock.Anything, mock.Anything).Return(test.Version, nil)
 
 			var gitAPI = git.CLI{Commander: cmder}
-			var versionAPI = API{GitAPI: gitAPI}
+			var versionAPI = API{Prefix: test.Prefix, GitAPI: gitAPI}
 
 			var got, err = versionAPI.GetVersion()
 
@@ -121,12 +125,13 @@ func TestAPI_GetVersionOrDefault(t *testing.T) {
 	}
 
 	type ErrorTest struct {
-		Error error
-		Name  string
+		Error  error
+		Prefix string
+		Name   string
 	}
 
 	var errorTests = []ErrorTest{
-		{Name: "ReturnDefaultVersionOnGitApiError", Error: fmt.Errorf("some-error")},
+		{Name: "ReturnDefaultVersionOnGitApiError", Prefix: "v", Error: fmt.Errorf("some-error")},
 	}
 
 	for _, test := range errorTests {
@@ -135,7 +140,7 @@ func TestAPI_GetVersionOrDefault(t *testing.T) {
 			cmder.On("Output", mock.Anything, mock.Anything).Return("", test.Error)
 
 			var gitAPI = git.CLI{Commander: cmder}
-			var versionAPI = API{GitAPI: gitAPI}
+			var versionAPI = API{Prefix: test.Prefix, GitAPI: gitAPI}
 
 			var got = versionAPI.GetVersionOrDefault(cli.DefaultVersion)
 
@@ -148,14 +153,15 @@ func TestAPI_PredictVersion(t *testing.T) {
 	type Test struct {
 		Mode    modes.Mode
 		Name    string
+		Prefix  string
 		Version string
 		Want    string
 	}
 
 	var tests = []Test{
-		{Name: "ReturnPatchPrediction", Mode: modes.NewPatchMode(), Version: "0.0.0", Want: "0.0.1"},
-		{Name: "ReturnMinorPrediction", Mode: modes.NewMinorMode(), Version: "0.0.0", Want: "0.1.0"},
-		{Name: "ReturnMajorPrediction", Mode: modes.NewMajorMode(), Version: "0.0.0", Want: "1.0.0"},
+		{Name: "ReturnPatchPrediction", Prefix: "v", Mode: modes.NewPatchMode(), Version: "0.0.0", Want: "0.0.1"},
+		{Name: "ReturnMinorPrediction", Prefix: "v", Mode: modes.NewMinorMode(), Version: "0.0.0", Want: "0.1.0"},
+		{Name: "ReturnMajorPrediction", Prefix: "v", Mode: modes.NewMajorMode(), Version: "0.0.0", Want: "1.0.0"},
 	}
 
 	for _, test := range tests {
@@ -164,7 +170,7 @@ func TestAPI_PredictVersion(t *testing.T) {
 			cmder.On("Output", mock.Anything, mock.Anything).Return(test.Version, nil)
 
 			var gitAPI = git.CLI{Commander: cmder}
-			var versionAPI = API{GitAPI: gitAPI}
+			var versionAPI = API{Prefix: test.Prefix, GitAPI: gitAPI}
 
 			var got, err = versionAPI.PredictVersion(test.Version, test.Mode)
 
@@ -176,19 +182,20 @@ func TestAPI_PredictVersion(t *testing.T) {
 	type ErrorTest struct {
 		Error   error
 		Name    string
+		Prefix  string
 		Version string
 	}
 
 	var errorTests = []ErrorTest{
-		{Name: "ReturnErrorOnModeIncrementError", Error: fmt.Errorf("some-error"), Version: "invalid"},
+		{Name: "ReturnErrorOnModeIncrementError", Prefix: "v", Error: fmt.Errorf("some-error"), Version: "invalid"},
 	}
 
 	for _, test := range errorTests {
 		t.Run(test.Name, func(t *testing.T) {
-			var versionAPI = API{}
+			var versionAPI = API{Prefix: test.Prefix}
 
 			var mode = mocks.NewMockMode()
-			mode.On("Increment", mock.Anything).Return(test.Version, test.Error)
+			mode.On("Increment", mock.Anything, mock.Anything).Return(test.Version, test.Error)
 
 			var _, got = versionAPI.PredictVersion("0.0.0", mode)
 
@@ -215,9 +222,9 @@ func TestAPI_PushVersion(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
 			var gitAPI = fakes.NewFakeGitAPI()
-			var versionAPI = API{GitAPI: gitAPI}
+			var versionAPI = API{Prefix: test.Prefix, GitAPI: gitAPI}
 
-			var err = versionAPI.PushVersion(test.Version, test.Prefix)
+			var err = versionAPI.PushVersion(test.Version)
 
 			var pushedTags = versionAPI.GitAPI.(*fakes.FakeGitAPI).PushedTags
 			var got = pushedTags[len(pushedTags)-1]
@@ -243,9 +250,9 @@ func TestAPI_PushVersion(t *testing.T) {
 			cmder.On("Run", mock.Anything, mock.Anything).Return(test.Error)
 
 			var gitAPI = git.CLI{Commander: cmder}
-			var versionAPI = API{GitAPI: gitAPI}
+			var versionAPI = API{Prefix: "v", GitAPI: gitAPI}
 
-			var got = versionAPI.PushVersion("0.0.1", "v")
+			var got = versionAPI.PushVersion("0.0.1")
 
 			assert.Error(t, got)
 			assert.Equal(t, test.Error, got, `want: "%s, got: "%s"`, test.Error, got)
@@ -270,9 +277,9 @@ func TestAPI_ReleaseVersion(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
 			var gitAPI = fakes.NewFakeGitAPI()
-			var versionAPI = API{GitAPI: gitAPI}
+			var versionAPI = API{Prefix: test.Prefix, GitAPI: gitAPI}
 
-			var err = versionAPI.ReleaseVersion(test.Version, test.Prefix)
+			var err = versionAPI.ReleaseVersion(test.Version)
 
 			var localTags = versionAPI.GitAPI.(*fakes.FakeGitAPI).LocalTags
 			var got = localTags[len(localTags)-1]
@@ -298,9 +305,9 @@ func TestAPI_ReleaseVersion(t *testing.T) {
 			cmder.On("Run", mock.Anything, mock.Anything).Return(test.Error)
 
 			var gitAPI = git.CLI{Commander: cmder}
-			var versionAPI = API{GitAPI: gitAPI}
+			var versionAPI = API{Prefix: "v", GitAPI: gitAPI}
 
-			var got = versionAPI.ReleaseVersion("0.0.1", "v")
+			var got = versionAPI.ReleaseVersion("0.0.1")
 
 			assert.Error(t, got)
 			assert.Equal(t, test.Error, got, `want: "%s, got: "%s"`, test.Error, got)
@@ -346,7 +353,7 @@ func TestAPI_UpdateVersion(t *testing.T) {
 
 func TestNewAPI(t *testing.T) {
 	t.Run("ValidateState", func(t *testing.T) {
-		var api = NewAPI()
+		var api = NewAPI("v")
 		assert.NotNil(t, api.GitAPI)
 	})
 }


### PR DESCRIPTION
It turns out the blang/semver only supports prefixes of 'v' when called with ParseTolerant so semverbot needs to handle remapping or trimming that correctly before passing into semver.

This commit updates the API struct to carry the configured Prefix and passes it down to the lower level implementation functions.

- Updated test data to include a prefix of "test-" which initially failed, and now passes.
- Updated test structs to include a Prefix field, used for delegation
- Added a new UpdateVersionOptions struct to pass thru to the UpdateVersion function, following the same structure as existing code

Fixes #58